### PR TITLE
Add symbol memory and callbacks on reactor failures

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "runeascend"
-version = "1.0.2"
+version = "1.1.0"
 description = "Runescape Trading Platform"
 authors = ["Charles Warren <ciwarren@mtu.edu>"]
 include = ["runeascend", "tests"]

--- a/runeascend/runeservant/seeker.py
+++ b/runeascend/runeservant/seeker.py
@@ -64,7 +64,7 @@ def main():
             ) or last_buy["high_time"] < now - pd.Timedelta("15 minutes"):
                 continue
             profit_per_item = (
-                last_buy["high"] - (last_buy["high"] * 0.01)
+                last_buy["high"] - (last_buy["high"] * 0.02)
             ) - last_sell["low"]
             limit = r.name_to_limit.get(symbol)
             potential_profit = profit_per_item * limit

--- a/runeascend/runespreader/publisher.py
+++ b/runeascend/runespreader/publisher.py
@@ -286,7 +286,7 @@ class hf_opp_publisher(publisher):
                 }
                 self.logger.info(f"High Frequency Opportunity on {symbol}")
             profit_per_item = (
-                last_buy["high"] - (last_buy["high"] * 0.01)
+                last_buy["high"] - (last_buy["high"] * 0.02)
             ) - last_sell["low"]
             limit = self.r.name_to_limit.get(symbol)
             if profit_per_item / last_sell["low"] > self.ROI_RATIO:


### PR DESCRIPTION
Add per run publisher state ability to opportunity signals...

Probably an argument we could add a ttl to entries, pickle them, and load them on restart, but this should be good enough for now.